### PR TITLE
API cleanup - likely version 3.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Mixmax <marcus@mixmax.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,29 +10,6 @@
 $ npm install search-string
 ```
 
-## Current Uses
-
-### data
-
-```
-SearchString.parse
-searchString.getParsedQuery
-searchString.getTextSegments
-```
-
-### app
-
-```
-SearchString.parse
-searchString.getConditionArray
-searchString.getAllText
-searchString.clone
-searchString.removeKeyword
-searchString.addEntry
-searchString.toString
-searchString.getParsedQuery
-```
-
 ## Usage
 
 ```javascript
@@ -42,19 +19,45 @@ const SearchString = require('search-string');
 const str = 'to:me -from:joe@acme.com foobar1 -foobar2';
 const searchString = SearchString.parse(str);
 
-/* Get text */
+/* Get text in different formats. */
 
 // [ { text: 'foorbar1', negated: false }, { text: 'foobar2', negated: true } ]
 searchString.getTextSegments();
 
+// `foobar1 -foobar2`
+searchString.getAllText();
 
-/* Get conditions in different formats */
 
+/* Get conditions in different formats. */
+
+// Standard format: Condition Array
+// [ { key: 'to', value: 'me', negated: false }, { key: 'from', value: 'joe@acme.com', negated: true } ]
+searchString.getConditionArray(); 
+
+// Alternate format: Parsed Query
 // { to: ['me'], excludes: { from: ['joe@acme.com'] }}
 searchString.getParsedQuery(); 
 
-// [ { key: 'to', value: 'me', negated: false }, { key: 'from', value: 'joe@acme.com', negated: true } ]
-searchString.getConditionArray(); 
+/* Or get text and conditions back in string format. */
+
+// `to:me -from:joe@acme.com foobar1 -foobar2`
+searchString.toString();
+
+
+/* Mutations exist as well for modifying an existing SearchString structure. */
+
+// `to:me foobar -foobar2`
+searchString.removeKeyword('from', true).toString()
+
+// `to:me from:jane@mixmax.com foobar1 -foobar2`
+searchString.addEntry('from', 'jane@mixmax.com', false).toString();
+
+
+/* clone operation instantiates a new version by copying over data. */
+
+// `to:me from:jane@mixmax.com foobar1 -foobar2`
+searchString.clone().toString();
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It parses typical Gmail-style search strings like:
 to:me -from@joe@mixmax.com foobar1 -foobar2
 ```
 
-And returns an instance of `SearchString` which can be mutated, return different data structures, or the gmail-style search string again.
+And returns an instance of `SearchString` which can be mutated, return different data structures, or return the gmail-style search string again.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,6 +10,29 @@
 $ npm install search-string
 ```
 
+## Current Uses
+
+### data
+
+```
+SearchString.parse
+searchString.getParsedQuery
+searchString.getTextSegments
+```
+
+### app
+
+```
+SearchString.parse
+searchString.getConditionArray
+searchString.getAllText
+searchString.clone
+searchString.removeKeyword
+searchString.addEntry
+searchString.toString
+searchString.getParsedQuery
+```
+
 ## Usage
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 [![Build Status](https://travis-ci.org/mixmaxhq/search-string.svg?branch=master)](https://travis-ci.org/mixmaxhq/search-string)
 
+It parses typical Gmail-style search strings like:
+
+```
+to:me -from@joe@mixmax.com foobar1 -foobar2
+```
+
+And returns an instance of `SearchString` which can be mutated, return different data structures, or the gmail-style search string again.
+
+
 ## Installation
 
 ```shell
@@ -16,7 +25,7 @@ $ npm install search-string
 const SearchString = require('search-string');
 
 // Perform parsing
-const str = 'to:me -from:joe@acme.com foobar1 -foobar2';
+const str = 'to:me -from:joe@mixmax.com foobar1 -foobar2';
 const searchString = SearchString.parse(str);
 
 /* Get text in different formats. */
@@ -31,16 +40,16 @@ searchString.getAllText();
 /* Get conditions in different formats. */
 
 // Standard format: Condition Array
-// [ { key: 'to', value: 'me', negated: false }, { key: 'from', value: 'joe@acme.com', negated: true } ]
+// [ { key: 'to', value: 'me', negated: false }, { key: 'from', value: 'joe@mixmax.com', negated: true } ]
 searchString.getConditionArray(); 
 
 // Alternate format: Parsed Query
-// { to: ['me'], excludes: { from: ['joe@acme.com'] }}
+// { to: ['me'], excludes: { from: ['joe@mixmax.com'] }}
 searchString.getParsedQuery(); 
 
 /* Or get text and conditions back in string format. */
 
-// `to:me -from:joe@acme.com foobar1 -foobar2`
+// `to:me -from:joe@mixmax.com foobar1 -foobar2`
 searchString.toString();
 
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "author": "Marcus Ericsson <marcus@mixmax.com> (https://mixmax.com)",
   "license": "MIT",
+  "keywords": ["query parser", "querystrings", "search", "search syntax parser", "search query"],
   "repository": "git@github.com:mixmaxhq/search-string.git",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
   },
   "author": "Marcus Ericsson <marcus@mixmax.com> (https://mixmax.com)",
   "license": "MIT",
-  "keywords": ["query parser", "querystrings", "search", "search syntax parser", "search query"],
+  "keywords": [
+    "query parser",
+    "querystrings",
+    "search",
+    "search syntax parser",
+    "search query"
+  ],
   "repository": "git@github.com:mixmaxhq/search-string.git",
   "dependencies": {},
   "devDependencies": {
@@ -28,7 +34,7 @@
     "babel-core": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "eslint": "^4.7.2",
-    "eslint-config-mixmax": "^0.7.0",
+    "eslint-config-mixmax": "^0.9.0",
     "jest": "^21.1.0",
     "jest-cli": "^21.1.0"
   }

--- a/src/searchString.js
+++ b/src/searchString.js
@@ -12,9 +12,8 @@ const DOUBLE_QUOTE = 'DOUBLE_QUOTE';
  * and text being searched.
  */
 class SearchString {
-  constructor(conditionArray, conditionMap, textSegments) {
+  constructor(conditionArray, textSegments) {
     this.conditionArray = conditionArray;
-    this.conditionMap = conditionMap;
     this.textSegments = textSegments;
   }
 
@@ -26,18 +25,9 @@ class SearchString {
   static parse(str, transformTextToConditions = []) {
     if (!str) str = '';
     const conditionArray = [];
-    const conditionMap = {};
     const textSegments = [];
 
     const addCondition = (key, value, negated) => {
-      const mapValue = { value, negated };
-      if (conditionMap[key]) {
-        const mapValues = [conditionMap[key]];
-        mapValues.push(mapValue);
-        conditionMap[key] = mapValues;
-      } else {
-        conditionMap[key] = mapValue;
-      }
       const arrayEntry = { keyword: key, value, negated };
       conditionArray.push(arrayEntry);
     };
@@ -158,23 +148,7 @@ class SearchString {
       addCondition(currentText, currentOperand, isNegated);
     }
 
-    return new SearchString(conditionArray, conditionMap, textSegments);
-  }
-
-  /**
-   * @return {Number} Number of unique operators that have operands associated with them.
-   */
-  getNumUniqueConditionKeys() {
-    return Object.keys(this.conditionMap).length;
-  }
-
-  /**
-   * DEPRECATED - Haven't found a use for it.
-   * @return {Object} map of conditions, if multiple conditions for a particular key exists,
-   *                  collapses them into one entry in the map.
-   */
-  _getConditionMap() {
-    return this.conditionMap;
+    return new SearchString(conditionArray, textSegments);
   }
 
   /**
@@ -215,30 +189,11 @@ class SearchString {
   }
 
   /**
-   * @return {String} space separated positive text segments
-   */
-  getText() {
-    return this.textSegments
-      .filter((textSegment) => !textSegment.negated)
-      .map((textSegment) => textSegment.text)
-      .join(' ');
-  }
-
-  /**
    * @return {Array} all text segment objects, negative or positive
    *                 e.g. { text: 'foobar', negated: false }
    */
   getTextSegments() {
     return this.textSegments;
-  }
-
-  /**
-   * @return {Array} Array of string of negated words
-   */
-  getNegatedWords() {
-    return this.textSegments
-      .filter((textSegment) => textSegment.negated)
-      .map((textSegment) => textSegment.text);
   }
 
   /**
@@ -267,11 +222,7 @@ class SearchString {
   }
 
   clone() {
-    return new SearchString(
-      this.conditionArray.slice(0),
-      Object.assign({}, this.conditionMap),
-      this.textSegments.slice(0)
-    );
+    return new SearchString(this.conditionArray.slice(0), this.textSegments.slice(0));
   }
 
   toString() {

--- a/src/searchString.js
+++ b/src/searchString.js
@@ -19,7 +19,7 @@ class SearchString {
     this.conditionArray = conditionArray;
     this.textSegments = textSegments;
     this.string = '';
-    this.stringDirty = true;
+    this.isStringDirty = true;
   }
 
   /**
@@ -215,7 +215,7 @@ class SearchString {
     this.conditionArray = this.conditionArray.filter(
       ({ keyword, negated }) => keywordToRemove !== keyword || negatedToRemove !== negated
     );
-    this.stringDirty = true;
+    this.isStringDirty = true;
   }
 
   /**
@@ -230,7 +230,7 @@ class SearchString {
       value,
       negated
     });
-    this.stringDirty = true;
+    this.isStringDirty = true;
   }
 
   /**
@@ -245,7 +245,7 @@ class SearchString {
    *                  Example string: `to:me -from:joe@acme.com foobar`
    */
   toString() {
-    if (this.stringDirty) {
+    if (this.isStringDirty) {
       // Group keyword, negated pairs as keys
       const conditionGroups = {};
       this.conditionArray.forEach(({ keyword, value, negated }) => {
@@ -282,7 +282,7 @@ class SearchString {
         }
       });
       this.string = `${conditionStr} ${this.getAllText()}`.trim();
-      this.stringDirty = false;
+      this.isStringDirty = false;
     }
     return this.string;
   }

--- a/src/searchString.js
+++ b/src/searchString.js
@@ -12,6 +12,9 @@ const DOUBLE_QUOTE = 'DOUBLE_QUOTE';
  * and text being searched.
  */
 class SearchString {
+  /**
+   * Not intended for public use. API could change.
+   */
   constructor(conditionArray, textSegments) {
     this.conditionArray = conditionArray;
     this.textSegments = textSegments;
@@ -184,6 +187,10 @@ class SearchString {
     return parsedQuery;
   }
 
+  /**
+   * @return {String} All text segments concateted together joined by a space.
+   *                  If a text segment is negated, it is preceded by a `-`.
+   */
   getAllText() {
     return this.textSegments
       ? this.textSegments.map(({ text, negated }) => (negated ? `-${text}` : text)).join(' ')
@@ -200,8 +207,9 @@ class SearchString {
 
   /**
    * Removes keyword-negated pair that matches inputted.
-   * @param {String} keywordToRemove 
-   * @param {String} negatedToRemove 
+   * Only removes if entry has same keyword/negated combo.
+   * @param {String} keywordToRemove Keyword to remove.
+   * @param {Boolean} negatedToRemove Whether or not the keyword removed is negated.
    */
   removeKeyword(keywordToRemove, negatedToRemove) {
     this.conditionArray = this.conditionArray.filter(
@@ -211,10 +219,10 @@ class SearchString {
   }
 
   /**
-   * 
-   * @param {String} keyword 
-   * @param {String} value 
-   * @param {Boolean} negated 
+   * Adds a new entry to search string. Does not dedupe against existing entries.
+   * @param {String} keyword  Keyword to add.
+   * @param {String} value    Value for respecitve keyword.
+   * @param {Boolean} negated Whether or not keyword/value pair should be negated.
    */
   addEntry(keyword, value, negated) {
     this.conditionArray.push({
@@ -225,10 +233,17 @@ class SearchString {
     this.stringDirty = true;
   }
 
+  /**
+   * @return {SearchString} A new instance of this class based on current data. 
+   */
   clone() {
     return new SearchString(this.conditionArray.slice(0), this.textSegments.slice(0));
   }
 
+  /**
+   * @return {String} Returns this instance synthesized to a string format.
+   *                  Example string: `to:me -from:joe@acme.com foobar`
+   */
   toString() {
     if (this.stringDirty) {
       // Group keyword, negated pairs as keys

--- a/tests/searchString.test.js
+++ b/tests/searchString.test.js
@@ -168,6 +168,8 @@ describe('searchString', () => {
     );
     parsed.removeKeyword('op1', false);
     expect(parsed.toString()).toEqual('op2:"multi, \'word\', value" -op3:value sometext more text');
+    // Check once more to see if cached copy returns correctly.
+    expect(parsed.toString()).toEqual('op2:"multi, \'word\', value" -op3:value sometext more text');
     parsed.removeKeyword('op3', false);
     expect(parsed.toString()).toEqual('op2:"multi, \'word\', value" -op3:value sometext more text');
     parsed.removeKeyword('op3', true);
@@ -298,7 +300,7 @@ describe('searchString', () => {
     expect(parsed.toString()).toEqual('-to:foo@foo.com,foo2@foo.com text');
   });
 
-  test('transformTexttoCondition', () => {
+  test('transformTextToCondition', () => {
     const str = '<a@b.com> to:c@d.com';
     const transform = (text) => (text === '<a@b.com>' ? { key: 'to', value: 'a@b.com' } : null);
     const parsed = SearchString.parse(str, [transform]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,9 +1073,9 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.5.6"
 
-eslint-config-mixmax@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-mixmax/-/eslint-config-mixmax-0.7.0.tgz#dd0d6215845730b07da0102beda3707a1283e3e8"
+eslint-config-mixmax@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-mixmax/-/eslint-config-mixmax-0.9.0.tgz#09fbffcb146e0445fc0bd55e779e1046c7103cc0"
   optionalDependencies:
     babel-eslint "^7.2.3"
     eslint-plugin-react "^7.1.0"


### PR DESCRIPTION
Had some time without internet over the weekend so did some tidying up now that our use of `search-string` sits on more solid ground.

In this PR:

- Readme updates to include recently added APIs.
- Removal of conditionMap data structure which we did not end up using.
- Removal of helper`getNumUniqueConditionKeys` which we have not had need for either.
- Caching toString result for quick follow-up retrieval. (Issue #11 )
- JSDoc for recently added APIs.
- MIT License file.

