### PR TITLE
`removeEntry` support

### DIFF
--- a/src/searchString.js
+++ b/src/searchString.js
@@ -221,7 +221,7 @@ class SearchString {
   /**
    * Adds a new entry to search string. Does not dedupe against existing entries.
    * @param {String} keyword  Keyword to add.
-   * @param {String} value    Value for respctitve keyword.
+   * @param {String} value    Value for respective keyword.
    * @param {Boolean} negated Whether or not keyword/value pair should be negated.
    */
   addEntry(keyword, value, negated) {
@@ -238,7 +238,7 @@ class SearchString {
    * it removes the first entry matched.
    *
    * @param {String} keyword  Keyword to remove.
-   * @param {String} value    Value for respectitve keyword.
+   * @param {String} value    Value for respective keyword.
    * @param {Boolean} negated Whether or not keyword/value pair is be negated.
    */
   removeEntry(keyword, value, negated) {

--- a/src/searchString.js
+++ b/src/searchString.js
@@ -234,6 +234,25 @@ class SearchString {
   }
 
   /**
+   * Removes an entry from the search string. If more than one entry with the same settings is found,
+   * it removes the first entry matched.
+   *
+   * @param {String} keyword  Keyword to remove.
+   * @param {String} value    Value for respecitve keyword.
+   * @param {Boolean} negated Whether or not keyword/value pair is be negated.
+   */
+  removeEntry(keyword, value, negated) {
+    const index = this.conditionArray.findIndex((entry) => {
+      return entry.keyword === keyword && entry.value === value && entry.negated === negated;
+    });
+
+    if (index === -1) return;
+
+    this.conditionArray.splice(index, 1);
+    this.isStringDirty = true;
+  }
+
+  /**
    * @return {SearchString} A new instance of this class based on current data. 
    */
   clone() {

--- a/src/searchString.js
+++ b/src/searchString.js
@@ -221,7 +221,7 @@ class SearchString {
   /**
    * Adds a new entry to search string. Does not dedupe against existing entries.
    * @param {String} keyword  Keyword to add.
-   * @param {String} value    Value for respecitve keyword.
+   * @param {String} value    Value for respctitve keyword.
    * @param {Boolean} negated Whether or not keyword/value pair should be negated.
    */
   addEntry(keyword, value, negated) {
@@ -238,7 +238,7 @@ class SearchString {
    * it removes the first entry matched.
    *
    * @param {String} keyword  Keyword to remove.
-   * @param {String} value    Value for respecitve keyword.
+   * @param {String} value    Value for respectitve keyword.
    * @param {Boolean} negated Whether or not keyword/value pair is be negated.
    */
   removeEntry(keyword, value, negated) {

--- a/tests/searchString.test.js
+++ b/tests/searchString.test.js
@@ -308,4 +308,37 @@ describe('searchString', () => {
     expect(getNumKeywords(parsed)).toEqual(1);
     expect(parsed.getParsedQuery().to).toEqual(['a@b.com', 'c@d.com']);
   });
+
+  test('removeEntry simple case', () => {
+    const str = 'foo:bar,baz';
+    const parsed = SearchString.parse(str);
+    expect(parsed.getParsedQuery().foo).toEqual(['bar', 'baz']);
+
+    parsed.removeEntry('foo', 'baz', false);
+
+    expect(parsed.getParsedQuery().foo).toEqual(['bar']);
+  });
+
+  test('removeEntry should remove only one case', () => {
+    const str = '-foo:bar,baz,bar,bar,bar';
+    const parsed = SearchString.parse(str);
+    expect(parsed.getParsedQuery().exclude.foo).toEqual(['bar', 'baz', 'bar', 'bar', 'bar']);
+
+    parsed.removeEntry('foo', 'bar', true);
+
+    expect(parsed.getParsedQuery().exclude.foo).toEqual(['baz', 'bar', 'bar', 'bar']);
+  });
+
+  test('removeEntry should be noop if entry is not found', () => {
+    const str = 'foo:bar';
+    const parsed = SearchString.parse(str);
+    expect(parsed.getParsedQuery().foo).toEqual(['bar']);
+    expect(parsed.toString()).toEqual('foo:bar');
+    expect(parsed.isStringDirty).toEqual(false);
+
+    parsed.removeEntry('foo', 'qux', false);
+
+    expect(parsed.getParsedQuery().foo).toEqual(['bar']);
+    expect(parsed.isStringDirty).toEqual(false);
+  });
 });


### PR DESCRIPTION
This PR implements a new method named `removeEntry`

It is similar to how `addEntry` works, it will find the first occurrence of the entry matching the passed parameters and remove from the `conditionArray`.